### PR TITLE
Return full path of the backup file segments

### DIFF
--- a/src/main/groovy/com/ee/tayra/io/RotatingFileCollection.groovy
+++ b/src/main/groovy/com/ee/tayra/io/RotatingFileCollection.groovy
@@ -43,7 +43,9 @@ class RotatingFileCollection {
   }
 
   private def findFilesInDirectory(String fileNameRegex, File directory) {
-    directory.listFiles().findAll{!it.isDirectory() && it.name.startsWith(fileNameRegex)}.collect {it.name}
+    directory.listFiles()
+             .findAll{!it.isDirectory() && it.name.startsWith(fileNameRegex)}
+             .collect { String.format( "%s%s%s", directory.absolutePath, File.separatorChar, it.name ) }
   }
 
   private def getAllRotatingFiles(String fileNameRegex, boolean isMultiple) throws Exception {


### PR DESCRIPTION
Scenario: I am trying to restore from multiple log files stored in /tmp/backup. Doing an "ls" on that folder would show
/tmp/backup/backup.log
/tmp/backup/backup.log.1
/tmp/backup/backup.log.2
/tmp/backup/backup.log.3
Now I try to restore using, restore.sh --file=/tmp/backup/backup.log --fAll --port=5555, all the backup files are not used because only file name is being returned and not the full path
