### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tayra  <a href="http://www.eelabs.co.uk/projects/tayra/"><img src="http://www.equalexperts.com/resources/img/eelogo.png" align="right"></a>
 ***Incremental backup tool for MongoDB***
-##Overview
+## Overview
 
  Tayra can be viewed as an external and persistent oplog that is stored on the 
  file system instead of residing within MongoDB. The files generated can then be


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
